### PR TITLE
Postgres support & tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ lint: ## check style with flake8 and typecheck with mypy
 test: ## run tests with the default Python
 	pytest --db-type sqlite
 	pytest --db-type duckdb
+	pytest --db-type postgresql
 
 test-all: ## run tests on every Python version with tox
 	tox

--- a/datools/explanations.py
+++ b/datools/explanations.py
@@ -103,7 +103,7 @@ def _explanation_counts_query(
         GROUP BY {GROUPING_SETS_KEY}
         ''')
     if min_support_rows is not None:
-        explanation_query += f'HAVING explanation_size > {min_support_rows}\n'
+        explanation_query += f'HAVING (1.0 * COUNT(*)) > {min_support_rows}\n'
 
     group_explanations_query, grouping_set_index = grouping_sets_query(
         engine,

--- a/datools/explanations.py
+++ b/datools/explanations.py
@@ -100,7 +100,7 @@ def _explanation_counts_query(
             {GROUP_COLUMNS_KEY},
             1.0 * COUNT(*) AS explanation_size
         FROM query
-        GROUP BY {GROUPING_SETS_KEY}
+        {GROUPING_SETS_KEY}
         ''')
     if min_support_rows is not None:
         explanation_query += f'HAVING (1.0 * COUNT(*)) > {min_support_rows}\n'

--- a/datools/explanations.py
+++ b/datools/explanations.py
@@ -145,8 +145,9 @@ def _diff_query(
                 {', '.join(f'test.{column.name}' for column in on_columns)},
                 test.explanation_size AS test_explanation_size,
                 control.explanation_size AS control_explanation_size,
-                (1.0 * test.explanation_size / (test.explanation_size
-                                          + COALESCE(control.explanation_size, 0)))
+                (1.0 * test.explanation_size
+                 / (test.explanation_size
+                   + COALESCE(control.explanation_size, 0)))
                 /
                 (1.0 * ({adjusted_test_rows} - test.explanation_size)
                  / (({adjusted_test_rows} - test.explanation_size)
@@ -280,6 +281,7 @@ def diff(
                 predicates += test_bucket_predicates[column][row[column.name]]
         # Some databases (e.g., PostgreSQL) cast `risk_ratio` as
         # Decimal, so we cast to float.
-        explanations.append(Explanation(tuple(predicates), float(row.risk_ratio)))
+        explanations.append(
+            Explanation(tuple(predicates), float(row.risk_ratio)))
     result.close()
     return explanations

--- a/datools/models.py
+++ b/datools/models.py
@@ -44,6 +44,14 @@ class Constant:
 class Aggregate:
     function: AggregateFunction
     column: Column
+    as_name: Column
+
+    def to_sql(self):
+        return (f'{self.function.name}({self.column.name}) '
+                f'AS {self.as_name.name}')
+
+    def __repr__(self):
+        return f'Aggregate({self.to_sql()})'
 
 
 @dataclass

--- a/datools/sqlalchemy_utils.py
+++ b/datools/sqlalchemy_utils.py
@@ -43,7 +43,7 @@ def query_rows(engine: sqlalchemy.engine.Engine, query: str) -> int:
     return rows
 
 
-def grouping_sets_query(
+def _native_grouping_sets_query(
         engine: sqlalchemy.engine.Engine,
         query: str,
         sets: Tuple[Tuple[Column, ...], ...],
@@ -51,32 +51,14 @@ def grouping_sets_query(
         grouping_sets_key: str = GROUPING_SETS_KEY,
         grouping_id_key: str = GROUPING_ID_KEY
 ) -> Tuple[str, Dict[int, Tuple[Column, ...]]]:
-    """Takes a `query` like
-
-    SELECT
-        {grouping_id_key} AS grouping_id,
-        {group_columns_key},
-        AGGREGATE1(args), AGGREGATE2(args)
-    ...
-    GROUP BY {grouping_sets_key}
-    ...
-
-    and returns a tuple with
-      * a grouping sets query for the grouping sets in `sets`, and
-      * a dictionary mapping set IDs to grouping set columns.
-
-    If the database that `engine` is connected to natively supports
-    grouping sets, utilize the standard SQL syntax for them. If it doesn't,
-    implement the query by capturing the UNION ALL output of multiple
-    GROUP BY subqueries.
-
-    The `grouping_id` will be set to a unique value for each grouping set,
-    and will be deterministic on the iteration order of `sets`.
     """
-    if engine.url.get_backend_name() == 'postgresql':
-        # TODO(marcua): Implement grouping sets using SQL syntax in
-        # databases that support it.
-        pass
+    For databases like DuckDB, Postgres, and Snowflake that natively
+    support GROUPING SETs, this function generates the SQL for a
+    GROUPING SETs query and assigns each set a group ID based on the
+    masking logic described in the Postgres documentation (whose
+    behavior seems to be shared with other databases):
+    https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-GROUPING-TABLE
+    """
     column_indices: Dict[Column, int] = {}
     for grouping_set in sets:
         for column in grouping_set:
@@ -99,3 +81,85 @@ def grouping_sets_query(
             .replace(group_columns_key, ', '.join(group_columns))
             .replace(grouping_sets_key, ', '.join(grouping_set_names)))
     return '\nUNION ALL\n'.join(queries), set_index
+
+
+def _synthetic_grouping_sets_query(
+        engine: sqlalchemy.engine.Engine,
+        query: str,
+        sets: Tuple[Tuple[Column, ...], ...],
+        group_columns_key: str = GROUP_COLUMNS_KEY,
+        grouping_sets_key: str = GROUPING_SETS_KEY,
+        grouping_id_key: str = GROUPING_ID_KEY
+) -> Tuple[str, Dict[int, Tuple[Column, ...]]]:
+    """
+    For databases like SQLite and Redshift, which don't natively
+    support GROUPING SETs, this function generates a synthetic `UNION
+    ALL`-based version that's probably slower but equivalent in
+    output.
+
+    """
+    column_indices: Dict[Column, int] = {}
+    for grouping_set in sets:
+        for column in grouping_set:
+            index = column_indices.get(column)
+            if index is None:
+                column_indices[column] = len(column_indices)
+
+    queries = []
+    set_index: Dict[int, Tuple[Column, ...]] = {}
+    for set_id, grouping_set in enumerate(sets):
+        set_index[set_id] = grouping_set
+        group_columns = [f'NULL AS {column.name}'
+                         for column in column_indices.keys()]
+        for column in grouping_set:
+            group_columns[column_indices[column]] = column.name
+        grouping_set_names = tuple(column.name for column in grouping_set)
+        group_by_columns = ', '.join(grouping_set_names)
+        group_by = (
+            f'{"GROUP BY" if len(group_by_columns) else ""} {group_by_columns}')
+        queries.append(
+            query
+            .replace(grouping_id_key, str(set_id))
+            .replace(group_columns_key, ', '.join(group_columns))
+            .replace(grouping_sets_key, group_by))
+    return '\nUNION ALL\n'.join(queries), set_index
+
+
+def grouping_sets_query(
+        engine: sqlalchemy.engine.Engine,
+        query: str,
+        sets: Tuple[Tuple[Column, ...], ...],
+        group_columns_key: str = GROUP_COLUMNS_KEY,
+        grouping_sets_key: str = GROUPING_SETS_KEY,
+        grouping_id_key: str = GROUPING_ID_KEY
+) -> Tuple[str, Dict[int, Tuple[Column, ...]]]:
+    """Takes a `query` like
+
+    SELECT
+        {grouping_id_key} AS grouping_id,
+        {group_columns_key},
+        AGGREGATE1(args), AGGREGATE2(args)
+    ...
+    {grouping_sets_key}
+    ...
+
+    and returns a tuple with
+      * a grouping sets query for the grouping sets in `sets`, and
+      * a dictionary mapping set IDs to grouping set columns.
+
+    If the database that `engine` is connected to natively supports
+    grouping sets, utilize the standard SQL syntax for them. If it doesn't,
+    implement the query by capturing the UNION ALL output of multiple
+    GROUP BY subqueries.
+
+    The `grouping_id` will be set to a unique value for each grouping set,
+    and will be deterministic on the iteration order of `sets`.
+    """
+    if engine.url.get_backend_name() == 'sqlite':
+        return _synthetic_grouping_sets_query(
+            engine, query, sets, group_columns_key,
+            grouping_sets_key, grouping_id_key)
+    else:
+        return _native_grouping_sets_query(
+            engine, query, sets, group_columns_key,
+            grouping_sets_key, grouping_id_key)

--- a/datools/sqlalchemy_utils.py
+++ b/datools/sqlalchemy_utils.py
@@ -116,7 +116,8 @@ def _synthetic_grouping_sets_query(
         grouping_set_names = tuple(column.name for column in grouping_set)
         group_by_columns = ', '.join(grouping_set_names)
         group_by = (
-            f'{"GROUP BY" if len(group_by_columns) else ""} {group_by_columns}')
+            f'{"GROUP BY" if len(group_by_columns) else ""} '
+            f'{group_by_columns}')
         queries.append(
             query
             .replace(grouping_id_key, str(set_id))

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,3 +14,5 @@ mypy==0.910
 jupyterlab==3.2.4
 m2r2==0.3.2
 duckdb-engine==0.1.8
+testing.postgresql==1.3.0
+psycopg2-binary==2.9.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,16 @@
 import pytest
 
-from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
+
+from .db_engine_creators import DuckDbEngineCreator
+from .db_engine_creators import PostgresqlEngineCreator
+from .db_engine_creators import SqliteEngineCreator
 
 
 DB_TYPE_TO_ENGINE_STRING = {
-    'sqlite': 'sqlite://',
-    'duckdb': 'duckdb:///:memory:'
+    'duckdb': DuckDbEngineCreator,
+    'sqlite': SqliteEngineCreator,
+    'postgresql': PostgresqlEngineCreator
 }
 
 
@@ -18,5 +22,6 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope='function')
 def db_engine(pytestconfig) -> Engine:
-    engine_string = DB_TYPE_TO_ENGINE_STRING[pytestconfig.getoption('db_type')]
-    return create_engine(engine_string)
+    creator = DB_TYPE_TO_ENGINE_STRING[pytestconfig.getoption('db_type')]()
+    yield creator.get_engine()
+    creator.teardown_engine()

--- a/tests/db_engine_creators.py
+++ b/tests/db_engine_creators.py
@@ -1,0 +1,43 @@
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from testing.postgresql import PostgresqlFactory
+
+
+class DbEngineCreator:
+
+    def get_engine(self) -> Engine:
+        raise NotImplementedError()
+
+    def teardown_engine(self):
+        pass
+
+
+class SqliteEngineCreator(DbEngineCreator):
+
+    def get_engine(self) -> Engine:
+        return create_engine('sqlite://')
+
+
+class DuckDbEngineCreator(DbEngineCreator):
+
+    def get_engine(self) -> Engine:
+        return create_engine('duckdb:///:memory:')
+
+
+class PostgresqlEngineCreator(DbEngineCreator):
+
+    # Lazy-loaded postgres factory: we only create it on the first
+    # instantiation of a PostgresqlEngineCreator.
+    POSTGRESQL_FACTORY = None
+
+    def __init__(self):
+        if PostgresqlEngineCreator.POSTGRESQL_FACTORY is None:
+            PostgresqlEngineCreator.POSTGRESQL_FACTORY = PostgresqlFactory(
+                cache_initialized_db=True)
+        self.postgresql = PostgresqlEngineCreator.POSTGRESQL_FACTORY()
+
+    def get_engine(self) -> Engine:
+        return create_engine(self.postgresql.url())
+
+    def teardown_engine(self):
+        self.postgresql.stop()

--- a/tests/test_sqlalchemy_utils.py
+++ b/tests/test_sqlalchemy_utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from operator import itemgetter
 from sqlalchemy.engine import Engine
 
 from datools.models import Aggregate
@@ -30,11 +31,13 @@ def test_grouping_sets(db_engine: Engine):
         assert('UNION ALL' not in query)
         assert('GROUPING SETS' in query)
     result = db_engine.execute(query)
+    sort_keys = ('grouping_id', 'created_at', 'sensor_id', 'num_rows')
     all_rows = [dict(row) for row in result]
+    all_rows.sort(key=itemgetter(*sort_keys))
 
     def dt(datetime_string):
         return engine_based_datetime(db_engine, datetime_string)
-    assert(all_rows == [
+    expected = [
         {'grouping_id': 0, 'created_at': dt('2021-05-05 11:00:00.000000'),
          'sensor_id': '1', 'num_rows': 1},
         {'grouping_id': 0, 'created_at': dt('2021-05-05 11:00:00.000000'),
@@ -67,4 +70,6 @@ def test_grouping_sets(db_engine: Engine):
          'sensor_id': '3', 'num_rows': 3},
         {'grouping_id': 3, 'created_at': None,
          'sensor_id': None, 'num_rows': 9}
-    ])
+    ]
+    expected.sort(key=itemgetter(*sort_keys))
+    assert(all_rows == expected)

--- a/tests/test_sqlalchemy_utils.py
+++ b/tests/test_sqlalchemy_utils.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+from sqlalchemy.engine import Engine
+from textwrap import dedent
+
+from datools.models import Column
+from datools.sqlalchemy_utils import GROUP_COLUMNS_KEY
+from datools.sqlalchemy_utils import GROUPING_ID_KEY
+from datools.sqlalchemy_utils import GROUPING_SETS_KEY
+from datools.sqlalchemy_utils import grouping_sets_query
+from .fixtures import generate_scorpion_testdb
+
+
+def test_grouping_sets(db_engine: Engine):
+    generate_scorpion_testdb(db_engine)
+    grouping_query = dedent(
+        f'''
+        SELECT
+            {GROUPING_ID_KEY} AS grouping_id,
+            {GROUP_COLUMNS_KEY},
+            COUNT(*) AS num_rows
+        FROM sensor_readings
+        {GROUPING_SETS_KEY}
+        ''')
+    query, set_index = grouping_sets_query(
+        db_engine, grouping_query, (
+            (Column('created_at'), Column('sensor_id')),
+            (Column('created_at'),),
+            (Column('sensor_id'),),
+            (),
+        ))
+    if db_engine.url.get_backend_name() == 'sqlite':
+        assert('UNION ALL' in query)
+        assert('GROUPING SETS' not in query)
+    else:
+        assert('UNION ALL' not in query)
+        assert('GROUPING SETS' in query)
+    result = db_engine.execute(query)
+    all_rows = [dict(row) for row in result]
+    assert(all_rows == [
+    ])


### PR DESCRIPTION
Resolves #31
* Testing updates
  * Refactors test suite to introduce `tests/db_engine_creators.py`, which allows for setup/teardown logic to spin up and tear down a PostgreSQL instance.
  * Introduces `postgresql` test db-type so that `pytest --db-type postgresql` is possible.
* Adds native GROUPING SETS support for databases that support it natively (e.g., Postgres, DuckDB, Snowflake) alongside synthetic grouping sets via UNION ALLs of individual GROUP BY queries for databases that don't have grouping sets support (e.g., SQLite, Redshift).
* Fixed a few things around the edges that Postgres required and previous databases did not (referencing aliased columns in a WHERE, handling Decimal vs. float on `diff`'s `risk_ratio`).