### PR TITLE
Update the example in order to run properly  in MacOS

### DIFF
--- a/examples/diff/intel-sensor.ipynb
+++ b/examples/diff/intel-sensor.ipynb
@@ -69,6 +69,13 @@
    "source": [
     "!wget http://db.csail.mit.edu/labdata/data.txt.gz\n",
     "!gunzip data.txt.gz\n",
+    "\n",
+    "'''\n",
+    "for MacOS users plese use this command insted \n",
+    "     !sed -i '' 1s/^/day time_of_day epoch moteid temperature humidity light voltage\\n/' data.txt\n",
+    "for more info : https://stackoverflow.com/questions/26081375/bsd-sed-extra-characters-at-the-end-of-d-command\n",
+    "'''\n",
+    "\n",
     "!sed -i '1s/^/day time_of_day epoch moteid temperature humidity light voltage\\n/' data.txt\n",
     "!head data.txt"
    ]
@@ -283,7 +290,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -297,7 +304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
OS X requires the extension to be explicitly specified. The workaround is to set an empty string