### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.md.
-3. The pull request should work for Python 3.6-3.10. If you submit a pull request,
+3. The pull request should work for Python 3.7-3.10. If you submit a pull request,
    GitHub Actions will automatically run tests for these versions.
 
 ## Tips

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,12 @@ test_requirements = ['pytest>=3', ]
 setup(
     author="Adam Marcus",
     author_email='marcua@marcua.net',
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, py310, flake8
+envlist = py37, py38, py39, py310, flake8
 
 [travis]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py36, py37, py38, flake8
+envlist = py36, py37, py38, py39, py310, flake8
 
 [travis]
 python =
+    3.10: py310
+    3.9: py39
     3.8: py38
     3.7: py37
-    3.6: py36
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
[DuckDB tests were failing on Python 3.6](https://github.com/marcua/datools/runs/7378297280?check_suite_focus=true), which was [end-of-lifed about 6 months ago](https://endoflife.date/python).